### PR TITLE
feat: webhook endpoint (#2)

### DIFF
--- a/src/main/java/org/dd2480/App.java
+++ b/src/main/java/org/dd2480/App.java
@@ -1,6 +1,7 @@
 package org.dd2480;
 
 import org.dd2480.handlers.RootHandler;
+import org.dd2480.handlers.WebhookHandler;
 
 import io.javalin.Javalin;
 
@@ -25,6 +26,7 @@ public class App {
      */
     private void buildRoutes() {
         this.app.get("/", new RootHandler());
+        this.app.post("/webhook", new WebhookHandler());
     }
 
     /**

--- a/src/main/java/org/dd2480/handlers/WebhookHandler.java
+++ b/src/main/java/org/dd2480/handlers/WebhookHandler.java
@@ -1,0 +1,132 @@
+package org.dd2480.handlers;
+
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.javalin.http.Context;
+import io.javalin.http.Handler;
+
+/**
+ * Handler for the webhook endpoint.
+ * 
+ * Respond on {@code POST /webhook}
+ * 
+ * Accepts GitHub webhook events and verifies the signature.
+ * 
+ * Only {@code ping} and {@code push} events are supported.
+ */
+public class WebhookHandler implements Handler {
+
+    private static final String GITHUB_WEBHOOK_SECRET = System.getenv().getOrDefault("GITHUB_WEBHOOK_SECRET",
+            "testingsecretdontuseme");
+    private static final String SIGNATURE_ALGORITHM = "HmacSHA256";
+    private static final Logger logger = LoggerFactory.getLogger(WebhookHandler.class);
+
+    @Override
+    public void handle(@NotNull Context ctx) {
+        String event = ctx.header("X-GitHub-Event");
+        String signature = ctx.header("X-Hub-Signature-256");
+        String body = ctx.body();
+
+        // 400 if missing signature
+        if (signature == null || signature.isEmpty()) {
+            logger.warn("Received webhook event without signature");
+            ctx.status(400);
+            ctx.result("No signature");
+            return;
+        }
+
+        // 400 if missing event type
+        if (event == null || event.isEmpty()) {
+            logger.warn("Received webhook event without event type");
+            ctx.status(400);
+            ctx.result("No event type");
+            return;
+        }
+
+        // Verify the signature
+        if (!verifySignature(signature, GITHUB_WEBHOOK_SECRET, body)) {
+            logger.warn("Received webhook event with invalid signature");
+            ctx.status(400);
+            ctx.result("Invalid signature");
+            return;
+        }
+
+        switch (event) {
+            case "ping" -> {
+                handlePing(ctx);
+            }
+            case "push" -> {
+                handlePush(ctx);
+            }
+            default -> {
+                logger.warn("Received webhook event with unknown event type: " + event);
+                ctx.status(204);
+            }
+        }
+    }
+
+    /**
+     * Handle a ping event.
+     * 
+     * @param ctx The Javalin context for the request
+     */
+    private void handlePing(Context ctx) {
+        ctx.result("pong");
+        ctx.status(200);
+    }
+
+    /**
+     * Handle a push event.
+     * 
+     * @param ctx The Javalin context for the request
+     */
+    private void handlePush(Context ctx) {
+        ctx.result("push");
+        ctx.status(200);
+    }
+
+    /**
+     * Verify the signature of some string payload.
+     * 
+     * @param signature The signature to verify
+     * @param key       the key to use for the HMAC algorithm
+     * @param payload   the payload to verify
+     * @return true iff the signature is valid, false if not or if an error occurred
+     */
+    public boolean verifySignature(String signature, String key, String payload) {
+        try {
+            // Calculate the HMAC256 hash of the payload
+            Mac mac = Mac.getInstance(SIGNATURE_ALGORITHM);
+            SecretKeySpec secretKeySpec = new SecretKeySpec(key.getBytes(), SIGNATURE_ALGORITHM);
+            mac.init(secretKeySpec);
+            byte[] hmacBytes = mac.doFinal(payload.getBytes(StandardCharsets.UTF_8));
+            StringBuilder hash = new StringBuilder();
+            for (byte b : hmacBytes) {
+                hash.append(String.format("%02x", b));
+            }
+            String expectedSignature = "sha256=" + hash.toString();
+            // Compare the calculated hash with the expected hash
+            return MessageDigest.isEqual(expectedSignature.getBytes(StandardCharsets.UTF_8),
+                    signature.getBytes(StandardCharsets.UTF_8));
+        } catch (NoSuchAlgorithmException e) {
+            logger.error("No such algorithm when verifying signature", e);
+        } catch (InvalidKeyException e) {
+            logger.error("Invalid key when verifying signature", e);
+        } catch (IllegalStateException e) {
+            logger.error("Illegal state when verifying signature", e);
+        }
+
+        return false;
+    }
+
+}

--- a/src/main/java/org/dd2480/handlers/WebhookHandler.java
+++ b/src/main/java/org/dd2480/handlers/WebhookHandler.java
@@ -91,6 +91,7 @@ public class WebhookHandler implements Handler {
      * @param ctx The Javalin context for the request
      */
     private void handlePush(Context ctx) {
+        // TODO: Handle push event properly once build system is implemented
         ctx.result("push");
         ctx.status(200);
     }

--- a/src/test/java/WebhookEndpointTest.java
+++ b/src/test/java/WebhookEndpointTest.java
@@ -1,0 +1,96 @@
+import org.dd2480.handlers.WebhookHandler;
+import org.junit.jupiter.api.Test;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.javalin.http.Context;
+
+public class WebhookEndpointTest {
+
+    private final Context ctx = mock(Context.class);
+
+    @Test
+    public void missing_signature_header_respond_400() {
+        WebhookHandler handler = new WebhookHandler();
+
+        when(ctx.header("X-GitHub-Event")).thenReturn("ping");
+        when(ctx.header("X-Hub-Signature-256")).thenReturn(null);
+
+        handler.handle(ctx);
+
+        verify(ctx).status(400);
+        verify(ctx).result("No signature");
+    }
+
+    @Test
+    public void missing_event_header_respond_400() {
+        WebhookHandler handler = new WebhookHandler();
+
+        when(ctx.header("X-GitHub-Event")).thenReturn(null);
+        when(ctx.header("X-Hub-Signature-256")).thenReturn("sha256=1234");
+
+        handler.handle(ctx);
+
+        verify(ctx).status(400);
+        verify(ctx).result("No event type");
+    }
+
+    @Test
+    public void invalid_signature_respond_400() {
+        WebhookHandler handler = new WebhookHandler();
+
+        when(ctx.header("X-GitHub-Event")).thenReturn("ping");
+        when(ctx.header("X-Hub-Signature-256")).thenReturn("sha256=1234");
+        when(ctx.body()).thenReturn("body");
+
+        handler.handle(ctx);
+
+        verify(ctx).status(400);
+        verify(ctx).result("Invalid signature");
+    }
+
+    @Test
+    public void valid_ping_event_handle_ping() {
+        WebhookHandler handler = new WebhookHandler();
+
+        when(ctx.header("X-GitHub-Event")).thenReturn("ping");
+        when(ctx.header("X-Hub-Signature-256"))
+                .thenReturn("sha256=3ef1e4784186add576ca5c6442a3538437e3cde305289be300f3567a47ef697c");
+        when(ctx.body()).thenReturn("body");
+
+        handler.handle(ctx);
+
+        verify(ctx).status(200);
+        verify(ctx).result("pong");
+    }
+
+    @Test
+    public void valid_push_event_handle_push() {
+        WebhookHandler handler = new WebhookHandler();
+
+        when(ctx.header("X-GitHub-Event")).thenReturn("push");
+        when(ctx.header("X-Hub-Signature-256"))
+                .thenReturn("sha256=3ef1e4784186add576ca5c6442a3538437e3cde305289be300f3567a47ef697c");
+        when(ctx.body()).thenReturn("body");
+
+        handler.handle(ctx);
+
+        verify(ctx).status(200);
+    }
+
+    @Test
+    public void unknown_event_respond_204() {
+        WebhookHandler handler = new WebhookHandler();
+
+        when(ctx.header("X-GitHub-Event")).thenReturn("unknown");
+        when(ctx.header("X-Hub-Signature-256"))
+                .thenReturn("sha256=3ef1e4784186add576ca5c6442a3538437e3cde305289be300f3567a47ef697c");
+        when(ctx.body()).thenReturn("body");
+
+        handler.handle(ctx);
+
+        verify(ctx).status(204);
+    }
+
+}


### PR DESCRIPTION
Add webhook endpoint.

Accepts two different event types; `ping`, and `push`.

Verifies the HMAC signature of the body using a secret to be sure that the request came from github.

Depends on #14 merge that first

Closes #2 