### PR TITLE
feat: add code skeletons (#16)

### DIFF
--- a/src/main/java/org/dd2480/Commit.java
+++ b/src/main/java/org/dd2480/Commit.java
@@ -1,0 +1,21 @@
+package org.dd2480;
+
+/**
+ * Encapsulates all data required to indentify a specific commit.
+ */
+public class Commit {
+
+    public final String repositoryOwner;
+    public final String repositoryName;
+    public final String hash;
+    public final String message;
+    public final String branch;
+
+    public Commit(String repositoryOwner, String repositoryName, String commitHash, String commitMessage, String branch) {
+        this.repositoryOwner = repositoryOwner;
+        this.repositoryName = repositoryName;
+        this.hash = commitHash;
+        this.message = commitMessage;
+        this.branch = branch;
+    }
+}

--- a/src/main/java/org/dd2480/GithubStatus.java
+++ b/src/main/java/org/dd2480/GithubStatus.java
@@ -1,0 +1,12 @@
+package org.dd2480;
+
+import org.dd2480.builder.BuildStatus;
+
+public class GithubStatus {
+
+    /**
+     * Set the status of a commit on GitHub.
+     */
+    public static void setCommitStatus(Commit commit, BuildStatus status, String description, String targetUrl) {
+    }
+}

--- a/src/main/java/org/dd2480/builder/BuildResult.java
+++ b/src/main/java/org/dd2480/builder/BuildResult.java
@@ -1,0 +1,22 @@
+package org.dd2480.builder;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Encapsulates the result of a single build.
+ */
+public class BuildResult {
+
+    public String repositoryOwner;
+    public String repositoryName;
+    public String branch;
+    public String commitHash;
+
+    public BuildStatus status;
+    public List<String> logs;
+
+    public Instant startTime;
+    public Instant endTime;
+
+}

--- a/src/main/java/org/dd2480/builder/BuildStatus.java
+++ b/src/main/java/org/dd2480/builder/BuildStatus.java
@@ -1,0 +1,8 @@
+package org.dd2480.builder;
+
+public enum BuildStatus {
+    SUCCESS,
+    FAILURE,
+    ERROR,
+    PENDING
+}

--- a/src/main/java/org/dd2480/builder/Builder.java
+++ b/src/main/java/org/dd2480/builder/Builder.java
@@ -1,0 +1,43 @@
+package org.dd2480.builder;
+
+import org.dd2480.Commit;
+
+public class Builder {
+
+    /**
+     * Build a project from the repository on a specific commit.
+     *
+     * Save the build result.
+     */
+    public static void buildProject(Commit commit) {
+
+    }
+
+    /**
+     * Fetch project files from a remote repository, for a specific branch and
+     * commit.
+     *
+     * Save locally in a temp folder and return the absolute path to that
+     * folder.
+     *
+     * Name the folder something appropriate and unique, like the commit hash.
+     */
+    public static String fetchProjectFiles(Commit commit) {
+        return "Project files fetched";
+    }
+
+    /**
+     * Save the build result so that it can be accessed at a later date.
+     */
+    public static void saveResult(BuildResult result) {
+
+    }
+
+    /**
+     * Get the build result for a specific commit.
+     */
+    public static BuildResult getResult(String commitHash) {
+        return new BuildResult();
+    }
+
+}


### PR DESCRIPTION
Add basic code skeletons for the building module and github status api.

Change as see fit, these are just meant as guidelines.

Closes #16 