### PR TITLE
feat: Fetch GitHub project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ build/
 mvnw
 mvnw.cmd
 .mvn/**
+
+### GitHub Data ###
+/temp/

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.dd2480</groupId>
     <artifactId>Assignment2</artifactId>
@@ -51,6 +51,11 @@
             <artifactId>mockito-core</artifactId>
             <version>4.6.1</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit</artifactId>
+            <version>5.10.0.202012080955-r</version>
         </dependency>
     </dependencies>
     <build>

--- a/src/main/java/org/dd2480/builder/Builder.java
+++ b/src/main/java/org/dd2480/builder/Builder.java
@@ -1,6 +1,11 @@
 package org.dd2480.builder;
 
+import java.io.File;
+import java.nio.file.Paths;
+
 import org.dd2480.Commit;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
 
 public class Builder {
 
@@ -15,15 +20,35 @@ public class Builder {
 
     /**
      * Fetch project files from a remote repository, for a specific branch and
-     * commit.
+     * commit. Files are put in a temp folder and named after the commit hash.
      *
-     * Save locally in a temp folder and return the absolute path to that
-     * folder.
-     *
-     * Name the folder something appropriate and unique, like the commit hash.
+     * @param commit A commit object
+     * @return The absolute path for the project files, or an empty string if
+     *         something went wrong
      */
     public static String fetchProjectFiles(Commit commit) {
-        return "Project files fetched";
+
+        String repoUrl = "https://github.com/" + commit.repositoryOwner + "/" + commit.repositoryName + ".git";
+
+        // Absolute path to project file location
+        String filePath = Paths.get("temp", commit.hash).toAbsolutePath().toString();
+
+        try {
+            // Clone the repo
+            Git git = Git.cloneRepository()
+                    .setURI(repoUrl)
+                    .setDirectory(new File(filePath))
+                    .call();
+
+            // Checkout specific branch and commit
+            git.checkout().setName(commit.branch).call();
+            git.checkout().setName(commit.hash).call();
+        } catch (GitAPIException e) {
+            e.printStackTrace();
+            return "";
+        }
+
+        return filePath;
     }
 
     /**

--- a/src/main/java/org/dd2480/builder/Builder.java
+++ b/src/main/java/org/dd2480/builder/Builder.java
@@ -81,8 +81,8 @@ public class Builder {
     }
 
     /**
-     * Fetch project files from a remote repository, for a specific branch and
-     * commit. Files are put in a temp folder and named after the commit hash.
+     * Fetch project files from a remote repository for a specific branch and
+     * commit. Files are put in a temporary folder and named after the commit hash.
      *
      * @param commit A commit object
      * @return The absolute path for the project files, or an empty string if
@@ -95,18 +95,22 @@ public class Builder {
         // Absolute path to project file location
         String filePath = Paths.get("temp", commit.hash).toAbsolutePath().toString();
 
-        try {
-            // Clone the repo
-            Git git = Git.cloneRepository()
-                    .setURI(repoUrl)
-                    .setDirectory(new File(filePath))
-                    .call();
-
+        /*
+         * Clones the directory and switches to correct branch and commit.
+         * 
+         * Is a try-with-resource block that automatically runs git.close() whenever the
+         * block finishes, even if an exception happens. This is important, otherwise
+         * it might cause issues when deleting the repo files.
+         */
+        try (Git git = Git
+                .cloneRepository()
+                .setURI(repoUrl)
+                .setDirectory(new File(filePath))
+                .call()) {
             // Checkout specific branch and commit
             git.checkout().setName(commit.branch).call();
             git.checkout().setName(commit.hash).call();
-        } catch (GitAPIException e) {
-            e.printStackTrace();
+        } catch (Exception e) { // Incorrect commit info or other issue
             return "";
         }
 

--- a/src/test/java/FetchProjectFilesTest.java
+++ b/src/test/java/FetchProjectFilesTest.java
@@ -1,0 +1,85 @@
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Comparator;
+import java.util.stream.Stream;
+
+import org.dd2480.Commit;
+import org.dd2480.builder.Builder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class FetchProjectFilesTest {
+    @Test
+    void canFetchProjectFiles_givenCorrectRepoInformation() {
+        String hash = "a905432a9aa118e218bc15d1dacf87e939c88f39";
+        Commit commit = new Commit("group-15-dd2480", "Assignment-2", hash, null, "main");
+        String path = Builder.fetchProjectFiles(commit);
+        String expectedPath = Paths.get("temp", hash).toAbsolutePath().toString();
+
+        assertEquals(expectedPath, path, "Path is incorrect");
+    }
+
+    @Test
+    void cannotFetchProjectFiles_givenIncorrectCommitHash() {
+        Commit commit = new Commit("group-15-dd2480", "Assignment-2", "incorrectHash", null, "main");
+        String path = Builder.fetchProjectFiles(commit);
+
+        assertEquals("", path, "Path should be empty if hash is invalid");
+    }
+
+    @Test
+    void cannotFetchProjectFiles_givenIncorrectBranch() {
+        Commit commit = new Commit("group-15-dd2480", "Assignment-2", "a905432a9aa118e218bc15d1dacf87e939c88f39", null,
+                "incorrectBranch");
+        String path = Builder.fetchProjectFiles(commit);
+
+        assertEquals("", path, "Path should be empty if branch is invalid");
+    }
+
+    @Test
+    void cannotFetchProjectFiles_givenIncorrectRepoName() {
+        Commit commit = new Commit("group-15-dd2480", "incorrectRepoName", "a905432a9aa118e218bc15d1dacf87e939c88f39",
+                null,
+                "main");
+        String path = Builder.fetchProjectFiles(commit);
+
+        assertEquals("", path, "Path should be empty if repository name is invalid");
+    }
+
+    @Test
+    void cannotFetchProjectFiles_givenIncorrectRepoOwner() {
+        Commit commit = new Commit("incorrectRepoOwner", "Assignment-2", "a905432a9aa118e218bc15d1dacf87e939c88f39",
+                null,
+                "main");
+        String path = Builder.fetchProjectFiles(commit);
+
+        assertEquals("", path, "Path should be empty if repository owner is invalid");
+    }
+
+    @AfterEach
+    void cleanup() {
+        // Deletes the temporary folder and its content
+        try {
+            deleteDirectory(Paths.get("temp"));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    void deleteDirectory(Path directory) throws IOException {
+        try (Stream<Path> pathStream = Files.walk(directory)) {
+            pathStream.sorted(Comparator.reverseOrder()) // We walk in reverse order so children are deleted first
+                    .map(Path::toFile) // We want a file, not a path
+                    .forEach(file -> {
+                        if (!file.isDirectory() && !file.setWritable(true)) // Fixes eventual permission errors
+                            System.err.println("Permission could not be changed for: " + file.toString());
+                        if (!file.delete())
+                            System.err.println("File could not be deleted: " + file.toString());
+                    });
+        }
+    }
+}


### PR DESCRIPTION
- Completed the `fetchProjectFiles` function.
- Used JGit to fetch the repo, added as a dependency in `pom.xml`.
- Changed `.gitignore` to ignore `temp` folder that `fetchProjectFiles` creates.

Closes #3