### PR TITLE
feat: add static file hosting (#6)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,12 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>io.javalin</groupId>
+            <artifactId>javalin-testtools</artifactId>
+            <version>6.4.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>2.0.16</version>

--- a/src/main/java/org/dd2480/App.java
+++ b/src/main/java/org/dd2480/App.java
@@ -17,7 +17,12 @@ public class App {
     public App(String bindIp, int port) {
         this.bindIp = bindIp;
         this.port = port;
-        this.app = Javalin.create();
+        this.app = Javalin.create(config -> {
+            config.staticFiles.add(staticConfig -> {
+                staticConfig.directory = "/static";
+                staticConfig.hostedPath = "/static";
+            });
+        });
         this.buildRoutes();
     }
 

--- a/src/main/resources/static/test.txt
+++ b/src/main/resources/static/test.txt
@@ -1,0 +1,1 @@
+Hello, static!

--- a/src/test/java/StaticHostTest.java
+++ b/src/test/java/StaticHostTest.java
@@ -1,0 +1,29 @@
+import org.dd2480.App;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+
+import io.javalin.Javalin;
+import io.javalin.testtools.JavalinTest;
+
+public class StaticHostTest {
+
+    @Test
+    public void get_missing_returns_404() {
+        Javalin app = new App("localhost", 9876).app;
+        JavalinTest.test(app, (server, client) -> {
+            assertEquals(404, client.get("/static").code());
+            assertEquals(404, client.get("/static/missing_file.txt").code());
+        });
+    }
+
+    @Test
+    public void get_test_file_return_body() {
+        Javalin app = new App("localhost", 9876).app;
+        JavalinTest.test(app, (server, client) -> {
+            var response = client.get("/static/test.txt");
+            assertEquals(200, response.code());
+            assertEquals("Hello, static!", response.body().string());
+        });
+    }
+
+}


### PR DESCRIPTION
Add static file hosting, anything in `src/main/resources/static` will be accessible at the `static/{filename}` endpoint.

Javalin-testtools is used to run most of a javalin server without actually making http requests during testing.

Closes #6