### PR TITLE
feat: make Builder non-static (#25)

### DIFF
--- a/src/main/java/org/dd2480/App.java
+++ b/src/main/java/org/dd2480/App.java
@@ -1,5 +1,6 @@
 package org.dd2480;
 
+import org.dd2480.builder.Builder;
 import org.dd2480.handlers.RootHandler;
 import org.dd2480.handlers.WebhookHandler;
 
@@ -13,6 +14,8 @@ public class App {
     public final Javalin app;
     private final String bindIp;
     private final int port;
+
+    public Builder builder = new Builder();
 
     /**
      * Create a new instance of the application.

--- a/src/main/java/org/dd2480/builder/Builder.java
+++ b/src/main/java/org/dd2480/builder/Builder.java
@@ -21,7 +21,7 @@ public class Builder {
      * @param commit A commit object
      *
      */
-    public static void buildProject(Commit commit) {
+    public void buildProject(Commit commit) {
         Instant startTime = Instant.now();
 
         // First fetch project files
@@ -57,7 +57,8 @@ public class Builder {
         BuildResult result = new BuildResult(commit, status, allLogs, startTime, endTime);
         saveResult(result);
     }
-    public static boolean runCommand(String command, String workingDir, List<String> output) {
+
+    public boolean runCommand(String command, String workingDir, List<String> output) {
         try {
             ProcessBuilder pb = new ProcessBuilder(command.split(" "));
             pb.directory(new File(workingDir));
@@ -88,7 +89,7 @@ public class Builder {
      * @return The absolute path for the project files, or an empty string if
      *         something went wrong
      */
-    public static String fetchProjectFiles(Commit commit) {
+    public String fetchProjectFiles(Commit commit) {
 
         String repoUrl = "https://github.com/" + commit.repositoryOwner + "/" + commit.repositoryName + ".git";
 
@@ -122,7 +123,7 @@ public class Builder {
      * @param result the BuildResult object from buildProject
      *
      */
-    public static void saveResult(BuildResult result) {
+    public void saveResult(BuildResult result) {
         try {
             FileOutputStream stream = new FileOutputStream(result.commitHash + ".dat");
             ObjectOutputStream out = new ObjectOutputStream(stream);
@@ -141,7 +142,7 @@ public class Builder {
      *
      * @return the result of the build
      */
-    public static BuildResult getResult(String commitHash) {
+    public BuildResult getResult(String commitHash) {
         try {
             FileInputStream stream = new FileInputStream(commitHash + ".dat");
             ObjectInputStream in = new ObjectInputStream(stream);

--- a/src/test/java/FetchProjectFilesTest.java
+++ b/src/test/java/FetchProjectFilesTest.java
@@ -1,5 +1,3 @@
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -10,14 +8,17 @@ import java.util.stream.Stream;
 import org.dd2480.Commit;
 import org.dd2480.builder.Builder;
 import org.junit.jupiter.api.AfterEach;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
 
 class FetchProjectFilesTest {
     @Test
     void canFetchProjectFiles_givenCorrectRepoInformation() {
+        Builder builder = new Builder();
+
         String hash = "a905432a9aa118e218bc15d1dacf87e939c88f39";
         Commit commit = new Commit("group-15-dd2480", "Assignment-2", hash, null, "main");
-        String path = Builder.fetchProjectFiles(commit);
+        String path = builder.fetchProjectFiles(commit);
         String expectedPath = Paths.get("temp", hash).toAbsolutePath().toString();
 
         assertEquals(expectedPath, path, "Path is incorrect");
@@ -25,37 +26,45 @@ class FetchProjectFilesTest {
 
     @Test
     void cannotFetchProjectFiles_givenIncorrectCommitHash() {
+        Builder builder = new Builder();
+
         Commit commit = new Commit("group-15-dd2480", "Assignment-2", "incorrectHash", null, "main");
-        String path = Builder.fetchProjectFiles(commit);
+        String path = builder.fetchProjectFiles(commit);
 
         assertEquals("", path, "Path should be empty if hash is invalid");
     }
 
     @Test
     void cannotFetchProjectFiles_givenIncorrectBranch() {
+        Builder builder = new Builder();
+
         Commit commit = new Commit("group-15-dd2480", "Assignment-2", "a905432a9aa118e218bc15d1dacf87e939c88f39", null,
                 "incorrectBranch");
-        String path = Builder.fetchProjectFiles(commit);
+        String path = builder.fetchProjectFiles(commit);
 
         assertEquals("", path, "Path should be empty if branch is invalid");
     }
 
     @Test
     void cannotFetchProjectFiles_givenIncorrectRepoName() {
+        Builder builder = new Builder();
+
         Commit commit = new Commit("group-15-dd2480", "incorrectRepoName", "a905432a9aa118e218bc15d1dacf87e939c88f39",
                 null,
                 "main");
-        String path = Builder.fetchProjectFiles(commit);
+        String path = builder.fetchProjectFiles(commit);
 
         assertEquals("", path, "Path should be empty if repository name is invalid");
     }
 
     @Test
     void cannotFetchProjectFiles_givenIncorrectRepoOwner() {
+        Builder builder = new Builder();
+
         Commit commit = new Commit("incorrectRepoOwner", "Assignment-2", "a905432a9aa118e218bc15d1dacf87e939c88f39",
                 null,
                 "main");
-        String path = Builder.fetchProjectFiles(commit);
+        String path = builder.fetchProjectFiles(commit);
 
         assertEquals("", path, "Path should be empty if repository owner is invalid");
     }

--- a/src/test/java/org/dd2480/builder/RunCommandTest.java
+++ b/src/test/java/org/dd2480/builder/RunCommandTest.java
@@ -5,39 +5,49 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.dd2480.builder.Builder.runCommand;
 import static org.junit.jupiter.api.Assertions.*;
 
 class RunCommandTest {
 
     @Test
     void shouldReturnFalse_whenInvalidDirectory() {
+        Builder builder = new Builder();
+
         List<String> output = new ArrayList<>();
-        boolean result = runCommand("echo Test", "invalidDir", output);
+        boolean result = builder.runCommand("echo Test", "invalidDir", output);
 
         assertFalse(result, "Command should fail due to invalid directory");
         assertFalse(output.isEmpty(), "Output should contain error messages");
     }
+
     @Test
-    void shouldReturnFalse_whenNullInput(){
+    void shouldReturnFalse_whenNullInput() {
+        Builder builder = new Builder();
+
         List<String> output = new ArrayList<>();
-        boolean result = runCommand(null, ".", output);
+        boolean result = builder.runCommand(null, ".", output);
 
         assertFalse(result, "Command should fail due to null input");
         assertFalse(output.isEmpty(), "Output should contain exception message");
     }
+
     @Test
-    void shouldReturnFalse_whenNonExistentCommandGiven(){
+    void shouldReturnFalse_whenNonExistentCommandGiven() {
+        Builder builder = new Builder();
+
         List<String> output = new ArrayList<>();
-        boolean result = runCommand("nonexistentcommand", ".", output);
+        boolean result = builder.runCommand("nonexistentcommand", ".", output);
 
         assertFalse(result, "Command should fail");
         assertFalse(output.isEmpty(), "Output should contain error messages");
     }
+
     @Test
-    void shouldReturnTrue_whenRightCommandGiven(){
+    void shouldReturnTrue_whenRightCommandGiven() {
+        Builder builder = new Builder();
+
         List<String> output = new ArrayList<>();
-        boolean result = runCommand("echo Hello, World!", ".", output);
+        boolean result = builder.runCommand("echo Hello, World!", ".", output);
 
         assertTrue(result, "Command should execute successfully");
         assertFalse(output.isEmpty(), "Output should not be empty");


### PR DESCRIPTION
Makes builder non-static to allow for easier mocking of its methods.

App contains an instance of the builder that we will pass around where necessary.

Closes #25 