### PR TITLE
feat: Add build page

### DIFF
--- a/src/main/java/org/dd2480/App.java
+++ b/src/main/java/org/dd2480/App.java
@@ -17,7 +17,11 @@ public class App {
     private final String bindIp;
     private final int port;
 
-    public Builder builder = new Builder();
+    public Builder builder;
+
+    public App(String bindIp, int port) {
+        this("localhost", 8080, new Builder());
+    }
 
     /**
      * Create a new instance of the application.
@@ -25,7 +29,7 @@ public class App {
      * @param bindIp The ip to bind the server to.
      * @param port   The port to bind the server to.
      */
-    public App(String bindIp, int port) {
+    public App(String bindIp, int port, Builder builder) {
         this.bindIp = bindIp;
         this.port = port;
         this.app = Javalin.create(config -> {
@@ -42,6 +46,7 @@ public class App {
             // Any templates in src/main/resources/templates can be used for rendering
             config.fileRenderer(new JavalinFreemarker());
         });
+        this.builder = builder;
         this.buildRoutes();
     }
 
@@ -51,7 +56,7 @@ public class App {
     private void buildRoutes() {
         this.app.get("/", new RootHandler());
         this.app.post("/webhook", new WebhookHandler());
-        this.app.get("/builds/{commitHash}", new BuildInfoHandler());
+        this.app.get("/builds/{commitHash}", new BuildInfoHandler(this.builder));
     }
 
     /**

--- a/src/main/java/org/dd2480/App.java
+++ b/src/main/java/org/dd2480/App.java
@@ -1,6 +1,7 @@
 package org.dd2480;
 
 import org.dd2480.builder.Builder;
+import org.dd2480.handlers.BuildInfoHandler;
 import org.dd2480.handlers.RootHandler;
 import org.dd2480.handlers.WebhookHandler;
 
@@ -50,6 +51,7 @@ public class App {
     private void buildRoutes() {
         this.app.get("/", new RootHandler());
         this.app.post("/webhook", new WebhookHandler());
+        this.app.get("/builds/{commitHash}", new BuildInfoHandler());
     }
 
     /**

--- a/src/main/java/org/dd2480/handlers/BuildInfoHandler.java
+++ b/src/main/java/org/dd2480/handlers/BuildInfoHandler.java
@@ -1,0 +1,46 @@
+package org.dd2480.handlers;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.dd2480.builder.BuildResult;
+import org.dd2480.builder.Builder;
+
+import io.javalin.http.Context;
+import io.javalin.http.Handler;
+
+/**
+ * Handler for list builds page.
+ */
+public class BuildInfoHandler implements Handler {
+
+    @Override
+    public void handle(Context ctx) {
+        String commitHash = ctx.pathParam("commitHash");
+        Builder builder = new Builder();
+        BuildResult build = builder.getResult(commitHash);
+        
+        if (build == null) {
+            ctx.status(404); // Build not found
+        } else {
+            var map = new HashMap<String, Object>();
+
+            // Fills in variables present in /templates/buildInfo.ftl
+            map.put("repository", build.repositoryOwner + "/" + build.repositoryName);
+            map.put("hash", build.commitHash);
+            map.put("status", build.status.toString());
+            switch (build.status) {
+                case SUCCESS -> map.put("statusStyle", "status-success");
+                case FAILURE -> map.put("statusStyle", "status-failure");
+                case PENDING -> map.put("statusStyle", "status-pending");
+                case ERROR -> map.put("statusStyle", "status-error");
+            }
+            map.put("branch", build.branch);
+            map.put("date", build.endTime.toString());
+            map.put("logs", build.logs);
+
+            ctx.render("/templates/buildInfo.ftl", Map.of("build", map));
+        }
+    }
+}

--- a/src/main/resources/templates/buildInfo.ftl
+++ b/src/main/resources/templates/buildInfo.ftl
@@ -74,12 +74,15 @@
                     <p>${build.repository}</p>
                     <p>${build.branch}</p>
                 </span>
-                <p>${build.message}</p>
-                <pre>
-                <#list logs as log>
-                    ${log}<br>
-                </#list>
-                </pre>
+                <#if build.logs?size == 0>
+                    <p>No logs available.</p>
+                <#else>
+                    <pre>
+                        <#list build.logs as log>
+                            ${log}
+                        </#list>
+                    </pre>
+                </#if>
             </span>
         </li>
     </ul>

--- a/src/main/resources/templates/buildInfo.ftl
+++ b/src/main/resources/templates/buildInfo.ftl
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Build Info</title>
+    <style>
+        li {
+            list-style-type: none;
+        }
+        .build {
+            display: block;
+            border: 1px solid black;
+            padding: 10px;
+            padding-top: 5px;
+            padding-bottom: 5px;
+            margin: 10px;
+            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+            transition: background-color 0.2s;
+        }
+        .build h2 {
+            margin: 0;
+            margin-bottom: 5px;
+        }
+        .build-info p {
+            margin: 0;
+            margin-bottom: 5px
+        }
+        .build-info {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            border-bottom: 1px solid black;
+        }
+        .repo-info p {
+            margin: 0;
+        }
+        .repo-info {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .status {
+            display: inline-block;
+            padding: 5px;
+            border-radius: 5px;
+            font-weight: bold;
+        }
+
+        .status-success {
+            background-color: green;
+        }
+        .status-failure {
+            background-color: red;
+        }
+        .status-pending {
+            background-color: orange;
+        }
+        .status-error {
+            background-color: red;
+        }
+    </style>
+</head>
+<body>
+    <h1>Build ${build.hash}</h1>
+    <ul>
+        <li>
+            <span class="build">
+                <span class="build-info">
+                    <p>${build.date}</p>
+                    <p class="status ${build.statusStyle}">${build.status}</p>
+                </span>
+                <span class="repo-info">
+                    <p>${build.repository}</p>
+                    <p>${build.branch}</p>
+                </span>
+                <p>${build.message}</p>
+                <pre>
+                <#list logs as log>
+                    ${log}<br>
+                </#list>
+                </pre>
+            </span>
+        </li>
+    </ul>
+</body>
+</html>

--- a/src/test/java/BuildInfoEndpointTest.java
+++ b/src/test/java/BuildInfoEndpointTest.java
@@ -1,29 +1,23 @@
-import org.dd2480.App;
-import org.dd2480.Commit;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.List;
 
+import org.dd2480.App;
+import org.dd2480.Commit;
 import org.junit.jupiter.api.Test;
 import org.dd2480.builder.BuildResult;
 import org.dd2480.builder.BuildStatus;
 import org.dd2480.builder.Builder;
-import org.dd2480.handlers.BuildInfoHandler;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import io.javalin.Javalin;
 import io.javalin.testtools.JavalinTest;
 
-public class BuildInfoEndpointTest {
+class BuildInfoEndpointTest {
 
     @Test
-    public void return404_whenRouteContainsIncorrectHash() {
+    void return404_whenRouteContainsIncorrectHash() {
         Javalin app = new App("localhost", 9876).app;
         JavalinTest.test(app, (server, client) -> {
             // Wrong hash should not give anything
@@ -32,17 +26,14 @@ public class BuildInfoEndpointTest {
     }
 
     @Test
-    public void returnBody_whenRouteContainsCorrectHash() {
-        App app = new App("localhost", 9876);
-
-        // BuildInfoHandler will call this function and expect a somewhat correct
-        // BuildResult object
+    void returnBody_whenRouteContainsCorrectHash() {
+        // BuildInfoHandler will call this function and get this mock object
         Builder builder = mock(Builder.class);
         when(builder.getResult("existentHash"))
                 .thenReturn(new BuildResult(new Commit("Owner", "Name", "existentHash", "Message", "main"),
                         BuildStatus.SUCCESS, new ArrayList<String>(), Instant.now(), Instant.now()));
 
-        app.builder = builder;
+        App app = new App("localhost", 9876, builder);
 
         JavalinTest.test(app.app, (server, client) -> {
             var response = client.get("/builds/existentHash");

--- a/src/test/java/BuildInfoEndpointTest.java
+++ b/src/test/java/BuildInfoEndpointTest.java
@@ -1,0 +1,58 @@
+import org.dd2480.App;
+import org.dd2480.Commit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.dd2480.builder.BuildResult;
+import org.dd2480.builder.BuildStatus;
+import org.dd2480.builder.Builder;
+import org.dd2480.handlers.BuildInfoHandler;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import io.javalin.Javalin;
+import io.javalin.testtools.JavalinTest;
+
+public class BuildInfoEndpointTest {
+
+    @Test
+    public void return404_whenRouteContainsIncorrectHash() {
+        Javalin app = new App("localhost", 9876).app;
+        JavalinTest.test(app, (server, client) -> {
+            // Wrong hash should not give anything
+            assertEquals(404, client.get("/builds/nonExistentHash").code());
+        });
+    }
+
+    @Test
+    public void returnBody_whenRouteContainsCorrectHash() {
+        App app = new App("localhost", 9876);
+
+        // BuildInfoHandler will call this function and expect a somewhat correct
+        // BuildResult object
+        Builder builder = mock(Builder.class);
+        when(builder.getResult("existentHash"))
+                .thenReturn(new BuildResult(new Commit("Owner", "Name", "existentHash", "Message", "main"),
+                        BuildStatus.SUCCESS, new ArrayList<String>(), Instant.now(), Instant.now()));
+
+        app.builder = builder;
+
+        JavalinTest.test(app.app, (server, client) -> {
+            var response = client.get("/builds/existentHash");
+
+            // Check for correct response code
+            assertEquals(200, response.code(), "Incorrect response code");
+
+            // Check that the content of the file contains BuildResult specific information
+            assertEquals(true, response.body().string().contains("existentHash"),
+                    "BuildResult specific information could not be found");
+        });
+    }
+}


### PR DESCRIPTION
- Added template for a build's info.
- Added a handler to render content from build results.
- Added two tests to verify the functionality of the handler.

The positive test does not work as the `Builder` instance in `BuildInfoHandler` is not overridden by the mock. The hash is correctly supplied to the handler, but the handler calls the actual `getResult()` method, which returns `null` since `existentHash.dat` does not exist.