### PR TITLE
fix: Fix `runCommand` OS dependency

### DIFF
--- a/src/main/java/org/dd2480/builder/Builder.java
+++ b/src/main/java/org/dd2480/builder/Builder.java
@@ -57,9 +57,18 @@ public class Builder {
         saveResult(result);
     }
 
+    
     public boolean runCommand(String command, String workingDir, List<String> output) {
         try {
-            ProcessBuilder pb = new ProcessBuilder(command.split(" "));
+            ProcessBuilder pb = new ProcessBuilder();
+
+            // Fix OS dependencies
+            if (System.getProperty("os.name").toLowerCase().contains("win")) {
+                pb.command("cmd.exe", "/c", command);
+            } else {
+                pb.command("sh", "-c", command);
+            }
+
             pb.directory(new File(workingDir));
             pb.redirectErrorStream(true);
 


### PR DESCRIPTION
- Added an OS check in the `runCommand` method so that the affected tests also works for Windows.

Closes #37