### PR TITLE
fix: Fix App constructor ignoring input parameters

### DIFF
--- a/src/main/java/org/dd2480/App.java
+++ b/src/main/java/org/dd2480/App.java
@@ -27,7 +27,7 @@ public class App {
      * @param port   The port number to bind the server to.
      */
     public App(String bindIp, int port) {
-        this("localhost", 8080, new Builder());
+        this(bindIp, port, new Builder());
     }
 
     /**


### PR DESCRIPTION
- Change hardcoded parameters to input paremeters in App constructor.

Closes #46 