### PR TITLE
fix: wrong directory for buildResults (#47)

### DIFF
--- a/src/main/java/org/dd2480/builder/Builder.java
+++ b/src/main/java/org/dd2480/builder/Builder.java
@@ -148,7 +148,12 @@ public class Builder {
      */
     public BuildResult getResult(String commitHash) {
         try {
-            FileInputStream stream = new FileInputStream(commitHash + ".dat");
+            File directory = new File("buildResults");
+            if (!directory.exists()) {
+                return null;
+            }
+            File file = new File(directory, commitHash + ".dat");
+            FileInputStream stream = new FileInputStream(file);
             ObjectInputStream in = new ObjectInputStream(stream);
             BuildResult result = (BuildResult) in.readObject();
             in.close();


### PR DESCRIPTION
Fix looking in the wrong directory for the build results.

Closes #47 