### PR TITLE
feat: return existing commit dir if one exists (#54)

### DIFF
--- a/src/main/java/org/dd2480/builder/Builder.java
+++ b/src/main/java/org/dd2480/builder/Builder.java
@@ -94,6 +94,11 @@ public class Builder {
 
         // Absolute path to project file location
         String filePath = Paths.get("temp", commit.hash).toAbsolutePath().toString();
+        File file = new File(filePath);
+        if (file.listFiles() != null) {
+            // Files for commit already exist
+            return filePath;
+        }
 
         /*
          * Clones the directory and switches to correct branch and commit.

--- a/src/test/java/FetchProjectFilesTest.java
+++ b/src/test/java/FetchProjectFilesTest.java
@@ -1,3 +1,4 @@
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -18,6 +19,27 @@ class FetchProjectFilesTest {
     @Test
     void canFetchProjectFiles_givenCorrectRepoInformation() {
         Builder builder = new Builder();
+
+        String hash = "a905432a9aa118e218bc15d1dacf87e939c88f39";
+        Commit commit = new Commit("group-15-dd2480", "Assignment-2", hash, null, "main");
+        String path = builder.fetchProjectFiles(commit);
+        String expectedPath = Paths.get("temp", hash).toAbsolutePath().toString();
+
+        assertEquals(expectedPath, path, "Path is incorrect");
+    }
+
+    @Test
+    void canFetchProjectFiles_givenCorrectRepoInformationAndFolderExists() {
+        Builder builder = new Builder();
+
+        File dir = new File("./temp/a905432a9aa118e218bc15d1dacf87e939c88f39");
+        dir.mkdirs();
+        File file = new File("./temp/a905432a9aa118e218bc15d1dacf87e939c88f39/test.txt");
+        try {
+            file.createNewFile();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
 
         String hash = "a905432a9aa118e218bc15d1dacf87e939c88f39";
         Commit commit = new Commit("group-15-dd2480", "Assignment-2", hash, null, "main");


### PR DESCRIPTION
Checks if a folder for the existing commit already exists, and returns it in that case, instead of attempting to pull again and potentially throwing an error.

Contents should not change over time for a specific commit hash.

Closes #54 